### PR TITLE
Feature: Add EC2 Cost Summary Feature with User-Selectable Date Range

### DIFF
--- a/aws/CondorUpdater.java
+++ b/aws/CondorUpdater.java
@@ -1,5 +1,7 @@
 package aws;
 
+import static utils.Constants.*;
+
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
@@ -22,7 +24,7 @@ public class CondorUpdater {
                 // 태그와 상태 조건 확인
                 boolean isMainTag = instance.getTags().stream()
                         .anyMatch(tag -> tag.getKey().equalsIgnoreCase("Role") && tag.getValue().equalsIgnoreCase("Main"));
-                if (isMainTag && "running".equalsIgnoreCase(instance.getState().getName())) {
+                if (isMainTag && STATE_RUNNING.equalsIgnoreCase(instance.getState().getName())) {
                     return instance.getPublicDnsName(); // Public DNS 반환
                 }
             }
@@ -32,7 +34,7 @@ public class CondorUpdater {
 
     // Condor 상태 확인
     public static void listCondorStatus(AmazonEC2 ec2) {
-        String pemKeyPath = ConfigLoader.getProperty("PEM_KEY_PATH");
+        String pemKeyPath = ConfigLoader.getProperty(PEM_KEY_PATH);
         String publicDns = getMainInstancePublicDns(ec2);
 
         if (publicDns == null) {
@@ -41,10 +43,9 @@ public class CondorUpdater {
         }
 
         SSHExecutor sshExecutor = new SSHExecutor(pemKeyPath);
-        String command = "condor_status";
 
         try {
-            String output = sshExecutor.executeCommand(publicDns, command);
+            String output = sshExecutor.executeCommand(publicDns, CONDOR_STATUS_COMMAND);
             System.out.println("                                                                                                              ");
             System.out.println("Condor Pool Status");
             System.out.println("--------------------------------------------------------------------------------------------------------------");

--- a/aws/MasterNodeManager.java
+++ b/aws/MasterNodeManager.java
@@ -30,7 +30,7 @@ public class MasterNodeManager {
 
         // 자동 승격 vs 수동 선택 질문
         System.out.println("Do you want to select the new Master node manually or let the system auto-select?");
-        System.out.println("Enter 'manual' for manual selection or 'auto' for automatic selection:");
+        System.out.print("Enter 'manual' for manual selection or 'auto' for automatic selection: ");
         String userChoice = scanner.nextLine();
 
         if (SELECTION_MANUAL.equalsIgnoreCase(userChoice)) {
@@ -59,7 +59,7 @@ public class MasterNodeManager {
 
         // 사용자로부터 선택 요청
         while (true) {
-            System.out.println("Enter the Instance ID of the Worker node to promote as the new Master:");
+            System.out.print("Enter the Instance ID of the Worker node to promote as the new Master: ");
             String selectedInstanceId = scanner.nextLine();
 
             Instance selectedInstance = workerNodes.stream()

--- a/aws/MasterNodeManager.java
+++ b/aws/MasterNodeManager.java
@@ -1,5 +1,7 @@
 package aws;
 
+import static utils.Constants.*;
+
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.CreateTagsRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
@@ -15,14 +17,13 @@ import java.util.logging.Logger;
 import utils.SSHExecutor;
 
 public class MasterNodeManager {
-    private static final String ROLE_WORKER = "Worker";
-    private static final String ROLE_MAIN = "Main";
-    private static final String STATE_RUNNING = "running";
-    private static final String SELECTION_MANUAL = "manual";
-    private static final String SELECTION_AUTO = "auto";
-
     private static final Logger LOGGER = Logger.getLogger(MasterNodeManager.class.getName());
     private static final Scanner scanner = new Scanner(System.in);
+
+    private static final String ALLOW_WRITE = "ALLOW_WRITE = *\n";
+    private static final String CONDOR_HOST = "CONDOR_HOST = ";
+    private static final String DAEMON_LIST_MASTER = "DAEMON_LIST = MASTER, SCHEDD, STARTD, COLLECTOR, NEGOTIATOR\n";
+    private static final String DAEMON_LIST_WORKER = "DAEMON_LIST = MASTER, STARTD\n";
 
     // Master 노드 승격 프로세스
     public static void startMasterNodePromotion(AmazonEC2 ec2) {
@@ -161,19 +162,19 @@ public class MasterNodeManager {
 
     private static String generateConfig(boolean isMaster, String masterPrivateDnsName) {
         StringBuilder config = new StringBuilder();
-        config.append("ALLOW_WRITE = *\n");
-        config.append("CONDOR_HOST = ").append(masterPrivateDnsName).append("\n");
+        config.append(ALLOW_WRITE);
+        config.append(CONDOR_HOST).append(masterPrivateDnsName).append("\n");
         if (isMaster) {
-            config.append("DAEMON_LIST = MASTER, SCHEDD, STARTD, COLLECTOR, NEGOTIATOR\n");
+            config.append(DAEMON_LIST_MASTER);
         } else {
-            config.append("DAEMON_LIST = MASTER, STARTD\n");
+            config.append(DAEMON_LIST_WORKER);
         }
         return config.toString();
     }
 
     // 설정 파일 업데이트
     private static void updateRemoteConfig(String publicDns, String configContent) {
-        String pemKeyPath = ConfigLoader.getProperty("PEM_KEY_PATH");
+        String pemKeyPath = ConfigLoader.getProperty(PEM_KEY_PATH);
         SSHExecutor sshExecutor = new SSHExecutor(pemKeyPath);
 
         String command = String.format("echo '%s' | sudo tee /etc/condor/config.d/condor_config.local", configContent);
@@ -186,7 +187,7 @@ public class MasterNodeManager {
     }
 
     private static void restartCondorService(String publicDns) {
-        String pemKeyPath = ConfigLoader.getProperty("PEM_KEY_PATH");
+        String pemKeyPath = ConfigLoader.getProperty(PEM_KEY_PATH);
         SSHExecutor sshExecutor = new SSHExecutor(pemKeyPath);
 
         String command = "sudo systemctl restart condor";
@@ -205,7 +206,7 @@ public class MasterNodeManager {
 
         Instance instance = result.getReservations().getFirst().getInstances().getFirst();
         return instance.getTags().stream()
-                .anyMatch(tag -> tag.getKey().equalsIgnoreCase("Role") && tag.getValue().equalsIgnoreCase(ROLE_MAIN));
+                .anyMatch(tag -> tag.getKey().equalsIgnoreCase(ROLE_TAG) && tag.getValue().equalsIgnoreCase(ROLE_MAIN));
     }
 
     private static List<Instance> getFilteredInstances(AmazonEC2 ec2, String role) {
@@ -218,9 +219,9 @@ public class MasterNodeManager {
             for (Reservation reservation : response.getReservations()) {
                 for (Instance instance : reservation.getInstances()) {
                     boolean matchesRole = role == null || instance.getTags().stream()
-                            .anyMatch(tag -> tag.getKey().equalsIgnoreCase("Role") && tag.getValue().equalsIgnoreCase(role));
+                            .anyMatch(tag -> tag.getKey().equalsIgnoreCase(ROLE_TAG) && tag.getValue().equalsIgnoreCase(role));
                     boolean matchesState = instance.getState().getName().equalsIgnoreCase(
-                                                MasterNodeManager.STATE_RUNNING);
+                            STATE_RUNNING);
 
                     if (matchesRole && matchesState) {
                         filteredInstances.add(instance);
@@ -241,7 +242,7 @@ public class MasterNodeManager {
                 // 각 인스턴스에 대해 개별적으로 태그 업데이트
                 CreateTagsRequest tagRequest = new CreateTagsRequest()
                         .withResources(instance.getInstanceId())
-                        .withTags(new Tag("Role", role));
+                        .withTags(new Tag(ROLE_TAG, role));
                 ec2.createTags(tagRequest);
 
                 LOGGER.info(String.format("Updated tag [Role=%s] for instance %s", role, instance.getInstanceId()));

--- a/libs/awssdk/aws-java-sdk-costexplorer-1.12.18.jar
+++ b/libs/awssdk/aws-java-sdk-costexplorer-1.12.18.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73d86d82a2357cf054d2208512bb39dafad3eff3c9b83128e14866e0997d50ad
+size 840992

--- a/utils/Constants.java
+++ b/utils/Constants.java
@@ -1,0 +1,12 @@
+package utils;
+
+public class Constants {
+    public static final String ROLE_TAG = "Role";
+    public static final String ROLE_MAIN = "Main";
+    public static final String ROLE_WORKER = "Worker";
+    public static final String STATE_RUNNING = "running";
+    public static final String SELECTION_MANUAL = "manual";
+    public static final String SELECTION_AUTO = "auto";
+    public static final String CONDOR_STATUS_COMMAND = "condor_status";
+    public static final String PEM_KEY_PATH = "PEM_KEY_PATH";
+}


### PR DESCRIPTION
This PR introduces a new feature to retrieve and display AWS EC2 cost summaries using the AWS Cost Explorer API. 

Key enhancements include:

- User Input for Date Range: Users can input a specific year and month to view cost data. The program dynamically calculates the date range from the start of the selected month to the month's end. For the current month, the range adjusts to today's date.
- Service-Level Grouping: The cost summary is grouped by service, providing detailed insights into AWS service usage.
- Improved Error Handling: Handles cases where no cost data is available for the selected period by displaying "$0" explicitly.
- Enhanced Output Format: User prompts and output formats are streamlined for a cleaner experience.